### PR TITLE
feat: add automated publish target to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ modplayer-wasm/www/modplayer-wasm-app-*.tgz
 .vscode/
 *.swp
 *.swo
+
+# Deployment
+.publish/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@
 #   make clean     - Clean all build artifacts
 #   make all       - Build everything (native + lib + wasm)
 
-.PHONY: build lib wasm wasm-dev test clean all check
+# Deployment
+PUBLISH_REPO = https://github.com/Gil-AdB/rust-modplayer
+PUBLISH_DIR = .publish
+
+.PHONY: build lib wasm wasm-dev test clean all check publish
 
 # Default target
 all: build lib wasm
@@ -47,3 +51,24 @@ clean:
 	rm -rf modplayer-wasm/pkg
 	rm -rf modplayer-wasm/www/dist
 	rm -rf modplayer-wasm/www/node_modules
+	rm -rf $(PUBLISH_DIR)
+
+# Publish to the production repo
+publish: wasm
+	@if [ ! -d "$(PUBLISH_DIR)" ]; then \
+		echo "Cloning deployment repository..."; \
+		git clone $(PUBLISH_REPO) $(PUBLISH_DIR); \
+	else \
+		echo "Updating deployment repository..."; \
+		cd $(PUBLISH_DIR) && git pull; \
+	fi
+	@echo "Building production bundles..."
+	cd modplayer-wasm/www && npm run build
+	@echo "Syncing files to $(PUBLISH_DIR)..."
+	find $(PUBLISH_DIR) -mindepth 1 -maxdepth 1 -not -name ".git" -not -name "README.md" -not -name "LICENSE" -exec rm -rf {} +
+	cp -r modplayer-wasm/www/dist/* $(PUBLISH_DIR)/
+	cd $(PUBLISH_DIR) && git add -A
+	@echo "----------------------------------------------------------"
+	@echo "SUCCESS: Build is staged in $(PUBLISH_DIR)"
+	@echo "Run 'cd $(PUBLISH_DIR) && git commit -m \"Update\" && git push' to deploy."
+	@echo "----------------------------------------------------------"


### PR DESCRIPTION
This PR adds a publish target to the Makefile that automates the deployment of build assets to the rust-modplayer repository. It also updates .gitignore to exclude the local .publish directory.