### PR TITLE
docs: add live demo link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A module music player written in Rust with terminal and WebAssembly backends.
 
-[**Live Demo**](https://diffuse2000.github.io/rust-modplayer/)
+[**Live Demo**](https://Gil-AdB.github.io/rust-modplayer/)
 
 ## 🌟 Overview
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A module music player written in Rust with terminal and WebAssembly backends.
 
+[**Live Demo**](https://diffuse2000.github.io/rust-modplayer/)
+
 ## 🌟 Overview
 
 **modplayer** is a module player that provides a way to listen to classic tracker music in the browser and the command line. It features a custom terminal-inspired interface with real-time channel visualization and basic effect support.


### PR DESCRIPTION
This PR adds a prominent link to the online version of the modplayer in the README. The link points to: https://Gil-AdB.github.io/rust-modplayer/