### PR TITLE
fix(external-audio): pump command channel before each tick

### DIFF
--- a/modplayer-lib/src/lib.rs
+++ b/modplayer-lib/src/lib.rs
@@ -148,13 +148,17 @@ extern "C" fn Modplayer_Create(path: *const c_char) -> *mut c_void {
 #[cfg(feature="external-audio")]
 #[unsafe(no_mangle)]
 extern "C" fn Modplayer_FillBuffer(app_ptr: *mut c_void, out: *mut f32, frames: u32) {
+    use std::ops::DerefMut;
     if app_ptr.is_null() || out.is_null() { return; }
     let self_ = unsafe { &mut *(app_ptr as *mut App) };
     let slice = unsafe { std::slice::from_raw_parts_mut(out, (frames as usize) * 2) };
     let mut song = self_.song_handle.get_song().lock().unwrap();
-    let (_tx, mut rx) = mpsc::channel::<PlaybackCmd>();
+    let mut rx = self_.song_handle.get_rx().lock().unwrap();
+    // Drain any commands sent via Modplayer_SetOrder (and the like) so the
+    // song state machine sees position changes before producing samples.
+    song.handle_commands(rx.deref_mut());
     let mut adaptar = InterleavedBufferAdaptar { buf: slice };
-    if let CallbackState::Complete = song.get_next_tick(&mut adaptar, &mut rx) {
+    if let CallbackState::Complete = song.get_next_tick(&mut adaptar, rx.deref_mut()) {
         // Song reached end — let host see it via the next call returning silence.
     }
 }

--- a/xmplayer/src/song_state/mod.rs
+++ b/xmplayer/src/song_state/mod.rs
@@ -178,6 +178,14 @@ impl SongState {
         &self.song
     }
 
+    /// Receiver side of the playback command channel. Embedders that drive
+    /// the song from a synchronous audio callback (no play_thread) need to
+    /// pump this so commands sent via the sender — set_order, etc. — are
+    /// observed by the song state machine.
+    pub fn get_rx(&self) -> &Arc<Mutex<Receiver<PlaybackCmd>>> {
+        &self.rx
+    }
+
     pub fn stop(&self) {
         self.stopped.store(true, Ordering::Release);
         self.triple_buffer_reader.wake_reader();


### PR DESCRIPTION
## Summary
Without a play_thread, commands sent via \`SongHandle::set_order\` (and the like) queued up forever in the \`SongState\` rx channel and the song never observed them.

\`Modplayer_FillBuffer\` now locks the real receiver and calls \`song.handle_commands(rx)\` before \`get_next_tick()\`, mirroring what \`SongState::callback()\` does on the play_thread path.

## Changes
- New \`SongState::get_rx()\` accessor (parallel to existing \`get_song()\`)
- \`Modplayer_FillBuffer\` drains the rx and applies commands each tick

## Test plan
- [x] \`SetPosition\` from \`Modplayer_SetOrder\` now reaches the song state in WASM builds