### PR TITLE
Embedder integration fixes (SDL_Quit thread, voice cut, display opt-out)

### DIFF
--- a/modplayer-lib/src/lib.rs
+++ b/modplayer-lib/src/lib.rs
@@ -95,6 +95,10 @@ impl App {
         self.song_handle.set_order(order);
     }
 
+    pub(crate) fn set_display(&mut self, on: bool) {
+        self.song_handle.set_display(on);
+    }
+
     fn close_audio(&mut self) {
         self.audio_output.close();
         self.song_handle.close();
@@ -136,6 +140,14 @@ extern "C" fn Modplayer_SetOrder(app_ptr: *mut c_void, order: u32) {
     let leaked_pointer = app_ptr as *mut App;
     let self_ = unsafe { &mut *leaked_pointer };
     self_.set_order(order);
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn Modplayer_SetDisplay(app_ptr: *mut c_void, on: bool) {
+    if app_ptr == 0 as *mut c_void {return;}
+    let leaked_pointer = app_ptr as *mut App;
+    let self_ = unsafe { &mut *leaked_pointer };
+    self_.set_display(on);
 }
 
 #[unsafe(no_mangle)]

--- a/modplayer-lib/src/lib.rs
+++ b/modplayer-lib/src/lib.rs
@@ -114,7 +114,12 @@ extern "C" fn Modplayer_Stop(app_ptr: *mut c_void) {
     let leaked_pointer = app_ptr as *mut App;
     let self_ = unsafe { &mut *leaked_pointer };
     self_.close_audio();
-    let _ = unsafe { Box::from_raw(self_) };
+    // Don't drop the App. Its AudioOutput owns the sdl2::Sdl context whose
+    // Drop calls SDL_Quit, which on macOS tears down windows via AppKit.
+    // AppKit is main-thread-only and Modplayer_Stop is typically called from
+    // an embedder's worker thread, which crashes with
+    // "Must only be used from the main thread". The host process is exiting
+    // anyway, so leak the App and let the OS reclaim memory.
 }
 
 #[unsafe(no_mangle)]

--- a/xmplayer/src/song/mod.rs
+++ b/xmplayer/src/song/mod.rs
@@ -409,6 +409,7 @@ pub enum PlaybackCmd {
     PauseToggle,
     FilterToggle,
     DisplayToggle,
+    SetDisplay(bool),
     ChannelToggle(u8),
     ChannelSolo(u8),
     ChannelUnmuteAll,
@@ -1321,6 +1322,7 @@ impl Song {
                         }
                     }
                     PlaybackCmd::DisplayToggle => {self.display = !self.display;}
+                    PlaybackCmd::SetDisplay(on) => {self.display = on;}
                     PlaybackCmd::ChannelToggle(channel) => {
                         if (channel as usize) < self.channels.len() {
                             self.channels[channel as usize].force_off = !self.channels[channel as usize].force_off;

--- a/xmplayer/src/song/mod.rs
+++ b/xmplayer/src/song/mod.rs
@@ -1382,6 +1382,13 @@ impl Song {
                         self.rate = self.original_rate;
                     }
                     PlaybackCmd::SetPosition(order) => {
+                        // Cut any voices still ringing from the previous
+                        // pattern; without this, a held note bleeds across
+                        // the jump and tails into the new section.
+                        for channel in self.channels.iter_mut() {
+                            channel.on = false;
+                            channel.voice.volume.set_volume(0);
+                        }
                         self.pattern_change.pattern = order as u8;
                         self.pattern_change.pattern_jump = true;
                         self.pattern_change.row = 0;

--- a/xmplayer/src/song_state/mod.rs
+++ b/xmplayer/src/song_state/mod.rs
@@ -94,6 +94,14 @@ impl SongState {
         if let Ok(_) = self.tx.send(PlaybackCmd::SetPosition(order)) {}
     }
 
+    /// Enable/disable the per-callback display path (oscilloscope copy,
+    /// channel-status snapshot, master FFT). Embedders that don't render
+    /// a visualizer should pass `false` to avoid ~22K complex muls/buffer
+    /// of pure waste. Defaults to true for backwards compatibility.
+    pub fn set_display(&self, on: bool) {
+        if let Ok(_) = self.tx.send(PlaybackCmd::SetDisplay(on)) {}
+    }
+
     fn callback(&self) {
         let mut song = self.song.lock().unwrap();
         let mut rx = self.rx.lock().unwrap();


### PR DESCRIPTION
## Summary

Three independent fixes that make modplayer easier to embed in hosts that own their own SDL window and don't render a visualizer.

### 1. \`Modplayer_Stop\` SIGTRAP on macOS

The \`App\` returned by \`Modplayer_Create\` owns an \`AudioOutput\` which owns an \`sdl2::Sdl\` context. When the sdl2 crate's \`Sdl\` drops it calls \`SDL_Quit\`, and on macOS \`SDL_Quit\` tears down windows via AppKit — main-thread-only. Embedders calling \`Modplayer_Stop\` from a worker thread trip:

\`\`\`
Application Specific Information:
Must only be used from the main thread

14  libSDL2-2.0.0.dylib  SDL_DestroyWindow_REAL
15  libSDL2-2.0.0.dylib  SDL_VideoQuit_REAL
17  libSDL2-2.0.0.dylib  SDL_Quit_REAL
18  modplayer            drop_in_place::<sdl::SdlDrop>
19  modplayer            Modplayer_Stop
\`\`\`

Pause audio via \`close_audio()\` but leak the \`App\` rather than dropping it. The host process is exiting anyway.

### 2. Held notes bleed across \`SetPosition\`

\`PlaybackCmd::SetPosition\` only updated \`pattern_change\` and called \`next_tick\`. Notes still ringing on a previous pattern's channels kept playing into the new section.

Silence all channels (\`on = false\`, \`volume = 0\`) before applying the jump, matching the same idiom used elsewhere when offset-past-end stops a sample.

### 3. \`SetDisplay\` command to suppress FFT when no visualizer

\`queue_display()\` runs unconditionally per audio buffer when \`self.display\` is true (default): channel-status snapshot, 512-sample oscilloscope copy, and a 2048-point complex FFT for the master spectrum. Headless embedders pay all of it for nothing.

Add \`PlaybackCmd::SetDisplay(bool)\` alongside existing \`DisplayToggle\`, plumbed through \`SongState::set_display\` and a \`Modplayer_SetDisplay\` C extern. Default stays \`true\` so visualizer embedders are unaffected.

## Test plan

- [x] \`cargo build --release -p modplayer-lib\` clean
- [ ] Embedder calls \`Modplayer_Stop\` from a non-main thread on macOS — process exits without SIGTRAP
- [ ] \`Modplayer_SetOrder\` jumping mid-playback no longer leaks tail of prior pattern
- [ ] \`Modplayer_SetDisplay(handle, false)\` followed by playback — no FFT cost, no visualizer data, audio unchanged